### PR TITLE
Adds a pod specification for cocoapods support.

### DIFF
--- a/SEFilterControl.podspec
+++ b/SEFilterControl.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+    s.name         = 'SEFilterControl'
+    s.version      = '0.0.1'
+    s.license      = 'MIT'
+    s.authors      = { 'Shady Elyaski' => 'shady@elyaski.com' }
+    s.homepage     = 'https://github.com/ShadyElyaski/ios-filter-control'
+    s.summary      = 'An iOS Filter UIControl Subclass. Zero Graphics. Highly Customizable.'
+    s.source       = { :git => 'https://github.com/ShadyElyaski/ios-filter-control.git', :commit => '0eb53f60f060c60b0eb99a8ffad30923ddeaab74' }
+    s.source_files = '*.{h,m}' 
+
+    s.platform = :ios
+end


### PR DESCRIPTION
We use your filter control in one of our projects that we're converting to use cocoapods. I've created a spec file for the SEFilterControl and submitted a pull request to the cocoapods specs repository.
